### PR TITLE
Removes transmisogynist wording from code of conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -2,4 +2,4 @@
 
 No harassment: Women Who Code is dedicated to providing a harassment-free event experience for everyone regardless of age, gender, sexual orientation, disability, physical appearance, race, or religion. We will not tolerate harassment of Women Who Code members in any form, including overly sexualized or demeaning comments or anything that threatens personal safety. People violating these rules may be sanctioned or expelled from the event and/or the organization at the discretion of the organizers and management team.
 
-All events are intended for people who identify as female or transgender. Men are encouraged to attend only when noted on a specific event.
+All events are intended for people who identify as women. Men are encouraged to attend only when noted on a specific event.


### PR DESCRIPTION
As per https://github.com/WomenWhoCode/guidelines-resources/issues/12.